### PR TITLE
fix: allow only one redirect for a site and outbound path combination

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: allow only one redirect for a site and outbound path combination
 
 1.0.0 (2022-09-08)
 ==================

--- a/aldryn_redirects/admin.py
+++ b/aldryn_redirects/admin.py
@@ -10,7 +10,8 @@ from django.utils.translation import gettext_lazy as _
 from parler.admin import TranslatableAdmin
 from tablib import Dataset
 
-from .forms import RedirectsImportForm, StaticRedirectsImportForm
+from .forms import (RedirectsImportForm, StaticRedirectForm,
+                    StaticRedirectsImportForm)
 from .models import (Redirect, StaticRedirect,
                      StaticRedirectInboundRouteQueryParam)
 
@@ -135,6 +136,7 @@ class StaticRedirectAdmin(DeletionMixin, admin.ModelAdmin):
     list_filter = ('sites',)
     list_display = ('inbound_route', 'outbound_route')
     search_fields = list_display
+    form = StaticRedirectForm
 
     # Custom attributes
     export_filename = 'static-redirects-%Y-%m-%d.csv'

--- a/aldryn_redirects/forms.py
+++ b/aldryn_redirects/forms.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from tablib import Dataset
 
 from .importers import RedirectImporter, StaticRedirectImporter
+from .models import StaticRedirect
 
 
 class RedirectsImportForm(forms.Form):
@@ -37,3 +38,29 @@ class RedirectsImportForm(forms.Form):
 
 class StaticRedirectsImportForm(RedirectsImportForm):
     importer_class = StaticRedirectImporter
+
+
+class StaticRedirectForm(forms.ModelForm):
+
+    def clean(self):
+        """
+        Adds validation to ensure that a StaticRedirect is unique between sites and the inbound_route
+        """
+        cleaned_data = super().clean()
+        sites = cleaned_data.get("sites")
+        inbound_route = cleaned_data.get("inbound_route")
+
+        existing_redirects = StaticRedirect.objects.filter(sites__in=sites, inbound_route=inbound_route).distinct()
+        if not existing_redirects:
+            return cleaned_data
+
+        other_redirects = existing_redirects.exclude(pk=self.instance.pk).distinct()
+        if not other_redirects:
+            return cleaned_data
+
+        sites = ", ".join(list(other_redirects.values_list("sites__domain", flat=True)))
+        raise ValidationError(f"Redirect already exists from '{inbound_route}' and the selected sites: {sites}")
+
+    class Meta:
+        model = StaticRedirect
+        fields = ["sites", "inbound_route", "outbound_route"]

--- a/aldryn_redirects/forms.py
+++ b/aldryn_redirects/forms.py
@@ -42,6 +42,10 @@ class StaticRedirectsImportForm(RedirectsImportForm):
 
 class StaticRedirectForm(forms.ModelForm):
 
+    class Meta:
+        model = StaticRedirect
+        fields = ["sites", "inbound_route", "outbound_route"]
+
     def clean(self):
         """
         Adds validation to ensure that a StaticRedirect is unique between sites and the inbound_route
@@ -60,7 +64,3 @@ class StaticRedirectForm(forms.ModelForm):
 
         sites = ", ".join(list(other_redirects.values_list("sites__domain", flat=True)))
         raise ValidationError(f"Redirect already exists from '{inbound_route}' and the selected sites: {sites}")
-
-    class Meta:
-        model = StaticRedirect
-        fields = ["sites", "inbound_route", "outbound_route"]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -29,6 +29,7 @@ HELPER_SETTINGS = {
         ('pt-br', 'Brazilian Portugues'),
     ],
     'SILENCED_SYSTEM_CHECKS': ['admin.E130'],
+    'SECRET_KEY': 'aldrynredirectstestsuitekey',
 }
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,92 @@
+from cms.test_utils.testcases import CMSTestCase
+from cms.utils import get_current_site
+from django.contrib.sites.models import Site
+from django.core.exceptions import ValidationError
+
+from aldryn_redirects.forms import StaticRedirectForm
+from aldryn_redirects.models import StaticRedirect
+
+
+class StaticRedirectFormTestCase(CMSTestCase):
+
+    def setUp(self):
+        self.site = get_current_site()
+        self.data = {
+            "sites": [str(self.site.pk)],
+            "inbound_route": "/test",
+            "outbound_route": "http://example.com",
+        }
+
+    def test_when_no_existing_redirect(self):
+        """
+        When a redirect for the given site and inbound path does not exist, the form is valid
+        """
+        form = StaticRedirectForm(data=self.data)
+        valid = form.is_valid()
+
+        self.assertTrue(valid)
+
+    def test_when_redirect_already_exists_for_site(self):
+        """
+        When a redirect for the given site and inbound path already exists, the form is valid
+        """
+        redirect = StaticRedirect.objects.create(
+            inbound_route=self.data["inbound_route"], outbound_route=self.data["outbound_route"],
+        )
+        redirect.sites.add(self.site)
+
+        form = StaticRedirectForm(data=self.data)
+        valid = form.is_valid()
+
+        self.assertFalse(valid)
+        with self.assertRaises(ValidationError):
+            form.clean()
+
+    def test_when_redirect_exists_for_another_site(self):
+        """
+        When a redirect exists for another site and the given path, the form is valid
+        """
+        other_site = Site.objects.create(domain="anothersite.example.com")
+        redirect = StaticRedirect.objects.create(
+            inbound_route=self.data["inbound_route"], outbound_route=self.data["outbound_route"],
+        )
+        redirect.sites.add(other_site)
+
+        form = StaticRedirectForm(data=self.data)
+        valid = form.is_valid()
+
+        self.assertTrue(valid)
+
+    def test_clean_when_redirect_for_other_site_exists_for_one_site(self):
+        """
+        When a redirect exists for a site, and a new redirect is added for the same path and the sites including the
+        same site, the form is not valid
+        """
+        other_site = Site.objects.create(domain="anothersite.example.com")
+        redirect = StaticRedirect.objects.create(
+            inbound_route=self.data["inbound_route"], outbound_route=self.data["outbound_route"],
+        )
+        redirect.sites.add(self.site)
+        self.data["sites"] = [self.site.pk, other_site.pk]
+
+        form = StaticRedirectForm(data=self.data)
+        valid = form.is_valid()
+
+        self.assertFalse(valid)
+        with self.assertRaises(ValidationError):
+            form.clean()
+
+    def test_when_adding_new_site_to_existing_redirect(self):
+        """
+        When a redirect exists for a site, and that redirect is updated to add another site, the form is valid
+        """
+        other_site = Site.objects.create(domain="anothersite.example.com")
+        redirect = StaticRedirect.objects.create(
+            inbound_route=self.data["inbound_route"], outbound_route=self.data["outbound_route"],
+        )
+        self.data["sites"] = [self.site.pk, other_site.pk]
+
+        form = StaticRedirectForm(data=self.data, instance=redirect)
+        valid = form.is_valid()
+
+        self.assertTrue(valid)


### PR DESCRIPTION
Adds a form to be used by the `StaticRedirectAdmin` to add validation to stop duplicate static redirects being created for a site and inbound path. 